### PR TITLE
removing refference to global docpad

### DIFF
--- a/src/jshint.plugin.coffee
+++ b/src/jshint.plugin.coffee
@@ -38,7 +38,7 @@ module.exports = (BasePlugin) ->
     # Render After
     # Called just just after we've rendered all the files.
     renderAfter: ({collection}) ->
-      if docpad.getEnvironment() is 'development'
+      if @docpad.getEnvironment() is 'development'
         config = @config
         ignoredPaths = [ ]
 


### PR DESCRIPTION
Apparently DocPad removed this in one of their releases...
